### PR TITLE
Add Strava Eng Blog Posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A curated list of awesome performance stories.
 | 2024/08/26 | [How We Switched from SQLite to DuckDB and Reduced Our Users’ Local Database Size by 97%](https://gladysassistant.com/blog/gladys-and-duckdb/)|
 | 2024/04/09 | [Optimizing Rust Protobuf Decoding Performance](https://www.greptime.com/blogs/2024-04-09-rust-protobuf-performance)|
 | 2024/03/06 | [How to speed up the Rust compiler in March 2024](https://nnethercote.github.io/2024/03/06/how-to-speed-up-the-rust-compiler-in-march-2024.html) |
+| 2024/01/18 | [Scaling Strava Challenge Leaderboards for Millions of Athletes](https://medium.com/strava-engineering/scaling-challenge-leaderboards-for-millions-of-athletes-9ab09ef01381) |
 | 2024/01/16 | [Web Perf Hero: Máté Szabó](https://techblog.wikimedia.org/2024/01/16/web-perf-hero-mate-szabo/)|
 | 2023/08/25 | [How to speed up the Rust compiler in August 2023](https://nnethercote.github.io/2023/08/25/how-to-speed-up-the-rust-compiler-in-august-2023.html) |
 | 2023/03/24 | [How to speed up the Rust compiler in March 2023](https://nnethercote.github.io/2023/03/24/how-to-speed-up-the-rust-compiler-in-march-2023.html) |
@@ -21,6 +22,7 @@ A curated list of awesome performance stories.
 | 2022/04/12 | [How to speed up the Rust compiler in April 2022](https://nnethercote.github.io/2022/04/12/how-to-speed-up-the-rust-compiler-in-april-2022.html) |
 | 2022/02/25 | [How to speed up the Rust compiler in 2022](https://nnethercote.github.io/2022/02/25/how-to-speed-up-the-rust-compiler-in-2022.html) |
 | 2021/11/12 | [The Rust compiler has gotten faster again](https://nnethercote.github.io/2021/11/12/the-rust-compiler-has-gotten-faster-again.html) |
+| 2021/05/26 | [Scaling Strava Club Leaderboard Infrastructure for Millions of Users](https://medium.com/strava-engineering/scaling-club-leaderboard-infrastructure-for-millions-of-users-9ee857ce8cfe) |
 | 2021/05/20 | [Extreme HTTP Performance Tuning: 1.2M API req/s on a 4 vCPU EC2 Instance](https://talawah.io/blog/extreme-http-performance-tuning-one-point-two-million/) |
 | 2020/08/05 | [How to speed up the Rust compiler some more in 2020](https://blog.mozilla.org/nnethercote/2020/08/05/how-to-speed-up-the-rust-compiler-some-more-in-2020/) |
 | 2020/04/24 | [How to speed up the Rust compiler in 2020](https://blog.mozilla.org/nnethercote/2020/04/24/how-to-speed-up-the-rust-compiler-in-2020/) |


### PR DESCRIPTION
Add 2 posts from the Strava Engineering Blog about scaling club and challenge leaderboards to handle millions of athletes while improving response times.

Saw your [post on X](https://x.com/DanielLockyer/status/1930555363436134584) asking for interesting performance stories. Here are a couple, if they fit what you're looking for!